### PR TITLE
Fixes Date Format Crash

### DIFF
--- a/Process.cs
+++ b/Process.cs
@@ -14,10 +14,10 @@ internal static class Process
                 continue;
             }
             // IN 24H FORMAT
-            var gameTime = World.DateTime;
-            bool isMorningRush = gameTime.Hour >= Settings.MRushStart && gameTime.Hour <= Settings.MRushEnd;
-            bool isLunchRush = gameTime.Hour >= Settings.LRushStart && gameTime.Hour <= Settings.LRushEnd;
-            bool isEveningRush = gameTime.Hour >= Settings.ERushStart && gameTime.Hour <= Settings.ERushEnd;
+            var gameTime = World.TimeOfDay;
+            bool isMorningRush = gameTime.Hours >= Settings.MRushStart && gameTime.Hours <= Settings.MRushEnd;
+            bool isLunchRush = gameTime.Hours >= Settings.LRushStart && gameTime.Hours <= Settings.LRushEnd;
+            bool isEveningRush = gameTime.Hours >= Settings.ERushStart && gameTime.Hours <= Settings.ERushEnd;
             int currentWeather = NativeFunction.Natives.GET_PREV_WEATHER_TYPE_HASH_NAME<int>();
 
             // airport


### PR DESCRIPTION
`[12/1/2024 4:27:44 PM.290] DynamicDensity: 
[12/1/2024 4:27:44 PM.290] DynamicDensity: ==============================
[12/1/2024 4:27:44 PM.290] DynamicDensity: UNHANDLED EXCEPTION DURING GAME FIBER TICK
[12/1/2024 4:27:44 PM.290] DynamicDensity: ------------------------------
[12/1/2024 4:27:44 PM.290] DynamicDensity: Origin: Game fiber "<UNNAMED THREAD>".
[12/1/2024 4:27:44 PM.290] DynamicDensity: ------------------------------
[12/1/2024 4:27:44 PM.290] DynamicDensity: Exception type: System.ArgumentOutOfRangeException
[12/1/2024 4:27:44 PM.290] DynamicDensity: Exception message: Month must be between one and twelve.
[12/1/2024 4:27:44 PM.290] Parameter name: month
[12/1/2024 4:27:44 PM.290] DynamicDensity: ------------------------------
[12/1/2024 4:27:44 PM.290] DynamicDensity: Inner exceptions:
[12/1/2024 4:27:44 PM.290] DynamicDensity: ------------------------------
[12/1/2024 4:27:44 PM.290] DynamicDensity: Stack trace:
[12/1/2024 4:27:44 PM.290] DynamicDensity: at System.DateTime.DaysInMonth(Int32 year, Int32 month)
[12/1/2024 4:27:44 PM.290] at Rage.World.get_DateTime()
[12/1/2024 4:27:44 PM.290] at DynamicDensity.Process.MainProcess() in C:\Users\steve\Desktop\Desktop Files\Coding\Projects\DynamicDensity\Process.cs:line 17
[12/1/2024 4:27:44 PM.290] at Rage.GameFiber.Main()
[12/1/2024 4:27:44 PM.290] DynamicDensity: ==============================
[12/1/2024 4:27:44 PM.290] DynamicDensity: `